### PR TITLE
Fix for '{#' being parsed as Jinja comment tag

### DIFF
--- a/scripts/transmission_check.j2
+++ b/scripts/transmission_check.j2
@@ -68,7 +68,7 @@ main () {
     check_user
     check_orders
 
-    if [[ "${#order_numbers_with_error[@]}" -gt 0 ]]; then
+    if [[ -n "${order_numbers_with_error[*]}" ]]; then
         send_alerts
     fi
 }


### PR DESCRIPTION
This change introduces a fix for the characters `{#` being parsed as a comment start tag leading to the following error: 

```
AnsibleError: template error while templating string: Missing end of comment tag.
```