### PR TITLE
Migrate EF auth code scripts

### DIFF
--- a/scripts/auth_code_stats.j2
+++ b/scripts/auth_code_stats.j2
@@ -1,0 +1,390 @@
+#!/bin/bash
+
+# Generate auth code stats and send by email.
+
+source "{{ informix_install_path }}/etc/informix.env.${USER}"
+
+# -- Internal variables -------------------------------------------------------
+
+script_name=$(basename "$0")
+
+database="ef_db"
+
+today="$(date)"
+today_with_hyphens="$(date --date="${today}" '+%d/%m/%Y')"
+today_with_slashes="$(date --date="${today}" '+%Y-%m-%d')"
+
+total_auth_codes_added=0
+total_auth_codes_removed=0
+auth_codes_removed_with_indicators=0
+
+log_file="{{ tuxedo_logs_path }}/${USER}/${script_name}.log"
+
+# -- General ------------------------------------------------------------------
+
+log () {
+    local level="${1}"
+    local message="$(echo -e "${2}")"
+    echo -e  "$(date --iso-8601=seconds) ${level} ${message}" | tee -a "${log_file}"
+}
+
+trace () {
+    local message="${1}"
+    if [[ "${log_level}" == "trace" ]]; then
+        log "TRACE" "${message}"
+    fi
+}
+
+error () {
+    local message="${1}"
+    log "ERROR" "${message}"
+}
+
+info () {
+    local message="${1}"
+    log "INFO" "${message}"
+}
+
+check_user () {
+    if [[ "${USER}" == "root" ]]; then
+        error "${script_name}: This script should be executed as a Tuxedo service user not root"
+        exit 1
+    fi
+}
+
+exit_on_error () {
+    local exit_code="$1"
+    local message="$2"
+
+    if [[ "${exit_code}" -ne 0 ]]; then
+        error "${message}"
+        exit 1
+    fi
+}
+
+create_mail_file () {
+    mail_file=$(mktemp -t "${script_name}.XXXXXXX")
+    exit_on_error "$?" "Unable to create temporary mail file (${FUNCNAME[0]}:${LINENO})"
+}
+
+add_stats_header () {
+    append_mail_file "Auth code processing statistics for ${today}\n\n"
+}
+
+add_auth_code_additions_header () {
+    append_mail_file "Auth code additions......\n\n" 
+}
+
+add_auth_change_action_n_count () {
+    local count; count=$(dbaccess "${database}" - 2>/dev/null <<EOF
+set isolation to dirty read;
+select count(*) from auth_change where
+completed = '${today_with_hyphens}'
+and action_ind = "N"
+and old_code is null;
+EOF
+)
+    exit_on_error "$?" "${FUNCNAME[0]}:${LINENO} dbaccess returned $?"
+
+    count="$(grep -Eo '[0-9]+' <<< "${count}")"
+
+    if [[ $? -ne 0 || -z "${count}" ]]; then
+        error "${FUNCNAME[0]}:${LINENO} Unable to determine row count"
+        exit 1
+    fi
+
+    (( total_auth_codes_added += count))
+    append_mail_file "Count of new auth codes added from web updates (Action ind N, letter type 1) : ${count}\n"
+}
+
+add_doc_auth_inc_count () {
+    local count; count=$(dbaccess "${database}" - 2>/dev/null <<EOF
+set isolation to dirty read;
+select count(*) from doc_auth where
+extend(doc_auth_start_dt,year to day) = "${today_with_slashes}"
+and doc_auth_end_dt is null
+and doc_auth_origin = "INC"
+EOF
+)
+    exit_on_error "$?" "${FUNCNAME[0]}:${LINENO} dbaccess returned $?"
+
+    count="$(grep -Eo '[0-9]+' <<< "${count}")"
+
+    if [[ $? -ne 0 || -z "${count}" ]]; then
+        error "${FUNCNAME[0]}:${LINENO} Unable to determine row count"
+        exit 1
+    fi
+
+    (( total_auth_codes_added += count))
+    append_mail_file "Count of new auth codes added on incorporation (No letter issued) : ${count}\n"
+}
+
+add_auth_change_action_r_count () {
+    local count; count=$(dbaccess "${database}" - 2>/dev/null <<EOF
+set isolation to dirty read;
+select count(*) from auth_change where
+completed = "${today_with_hyphens}"
+and action_ind = "R"
+EOF
+)
+    exit_on_error "$?" "${FUNCNAME[0]}:${LINENO} dbaccess returned $?"
+
+    count="$(grep -Eo '[0-9]+' <<< "${count}")"
+
+    if [[ $? -ne 0 || -z "${count}" ]]; then
+        error "${FUNCNAME[0]}:${LINENO} Unable to determine row count"
+        exit 1
+    fi
+
+    (( total_auth_codes_added += count))
+    append_mail_file "Count of new auth codes added to replace an existing code from the web (Action ind R, letter type 5) : ${count}\n"
+}
+
+add_auth_change_action_p_count () {
+    local count; count=$(dbaccess "${database}" - 2>/dev/null <<EOF
+set isolation to dirty read;
+select count(*) from auth_change where
+completed = "${today_with_hyphens}"
+and action_ind = "P"
+EOF
+)
+    exit_on_error "$?" "${FUNCNAME[0]}:${LINENO} dbaccess returned $?"
+
+    count="$(grep -Eo '[0-9]+' <<< "${count}")"
+
+    if [[ $? -ne 0 || -z "${count}" ]]; then
+        error "${FUNCNAME[0]}:${LINENO} Unable to determine row count"
+        exit 1
+    fi
+
+    (( total_auth_codes_added += count))
+    append_mail_file "Count of new auth codes added for a package request (Action ind P, letter type 3) : ${count}\n"
+}
+
+add_auth_codes_count_for_eshuttles () {
+    local count; count=$(dbaccess "${database}" - 2>/dev/null <<EOF
+set isolation to dirty read;
+select count(*) from doc_auth where
+extend(doc_auth_start_dt,year to day) = "${today_with_slashes}"
+and doc_auth_end_dt is null
+and doc_auth_origin = "ESH"
+EOF
+)
+    exit_on_error "$?" "${FUNCNAME[0]}:${LINENO} dbaccess returned $?"
+
+    count="$(grep -Eo '[0-9]+' <<< "${count}")"
+
+    if [[ $? -ne 0 || -z "${count}" ]]; then
+        error "${FUNCNAME[0]}:${LINENO} Unable to determine row count"
+        exit 1
+    fi
+
+    (( total_auth_codes_added += count))
+    append_mail_file "Count of auth codes added for e-shuttles (DOC1 Letter) : ${count}\n"
+}
+
+add_auth_codes_count_for_bulk_loads () {
+    local count; count=$(dbaccess "${database}" - 2>/dev/null <<EOF
+set isolation to dirty read;
+select count(*) from doc_auth where
+extend(doc_auth_start_dt,year to day) = "${today_with_slashes}"
+and doc_auth_end_dt is null
+and doc_auth_origin = "BUL"
+EOF
+)
+    exit_on_error "$?" "${FUNCNAME[0]}:${LINENO} dbaccess returned $?"
+
+    count="$(grep -Eo '[0-9]+' <<< "${count}")"
+
+    if [[ $? -ne 0 || -z "${count}" ]]; then
+        error "${FUNCNAME[0]}:${LINENO} Unable to determine row count"
+        exit 1
+    fi
+
+    (( total_auth_codes_added += count))
+    append_mail_file "Count of auth codes added for bulk loads (No letter issued) : ${count}\n"
+}
+
+add_auth_codes_count_for_ef_admin () {
+    local count; count=$(dbaccess "${database}" - 2>/dev/null <<EOF
+set isolation to dirty read;
+select count(*) from doc_auth where
+extend(doc_auth_start_dt,year to day) = "${today_with_slashes}"
+and doc_auth_end_dt is null
+and doc_auth_origin = "EFA"
+EOF
+)
+    exit_on_error "$?" "${FUNCNAME[0]}:${LINENO} dbaccess returned $?"
+
+    count="$(grep -Eo '[0-9]+' <<< "${count}")"
+
+    if [[ $? -ne 0 || -z "${count}" ]]; then
+        error "${FUNCNAME[0]}:${LINENO} Unable to determine row count"
+        exit 1
+    fi
+
+    (( total_auth_codes_added += count))
+    append_mail_file "Count of new auth codes manually updated by EF Admin (No letter issued) : ${count}\n\n"
+}
+
+add_total_count_new_auth_codes () {
+    append_mail_file "Total count of auth code additions for ${today_with_hyphens} : ${total_auth_codes_added}\n\n"
+}
+
+
+add_auth_code_reminder_letters_header () {
+    append_mail_file "Auth code reminder letters......\n\n"
+}
+
+add_doc_change_action_c_count () {
+    local count; count=$(dbaccess "${database}" - 2>/dev/null <<EOF
+set isolation to dirty read;
+select count(*) from auth_change where
+completed = "${today_with_hyphens}"
+and action_ind = "C"
+EOF
+)
+    exit_on_error "$?" "${FUNCNAME[0]}:${LINENO} dbaccess returned $?"
+
+    count="$(grep -Eo '[0-9]+' <<< "${count}")"
+
+    if [[ $? -ne 0 || -z "${count}" ]]; then
+        error "${FUNCNAME[0]}:${LINENO} Unable to determine row count"
+        exit 1
+    fi
+
+    append_mail_file "Count of Reminder letters issued for ${today_with_hyphens} (Action ind C, letter type 1) : ${count}\n\n"
+}
+
+add_auth_code_removals_header () {
+    append_mail_file "Auth code removals......\n\n"
+}
+
+add_auth_codes_count_for_bulk_removals () {
+    local count; count=$(dbaccess "${database}" - 2>/dev/null <<EOF
+set isolation to dirty read;
+select count(*) from doc_auth where
+doc_auth_end_dt = "${today_with_hyphens}"
+and (doc_auth_closed_by = "BULK" or doc_auth_closed_by = "BULKRES")
+EOF
+)
+    exit_on_error "$?" "${FUNCNAME[0]}:${LINENO} dbaccess returned $?"
+
+    count="$(grep -Eo '[0-9]+' <<< "${count}")"
+
+    if [[ $? -ne 0 || -z "${count}" ]]; then
+        error "${FUNCNAME[0]}:${LINENO} Unable to determine row count"
+        exit 1
+    fi
+
+    (( auth_codes_removed_with_indicators += count))
+    append_mail_file "Count of auth codes removed via bulk removal (No letter issued): ${count}\n"
+}
+
+add_auth_codes_count_for_cancelled_via_web () {
+    local count; count=$(dbaccess "${database}" - 2>/dev/null <<EOF
+set isolation to dirty read;
+select count(*) from auth_change where
+completed = "${today_with_hyphens}"
+and action_ind = "D"
+EOF
+)
+    exit_on_error "$?" "${FUNCNAME[0]}:${LINENO} dbaccess returned $?"
+
+    count="$(grep -Eo '[0-9]+' <<< "${count}")"
+
+    if [[ $? -ne 0 || -z "${count}" ]]; then
+        error "${FUNCNAME[0]}:${LINENO} Unable to determine row count"
+        exit 1
+    fi
+
+    (( auth_codes_removed_with_indicators += count))
+    append_mail_file "Count of auth codes cancelled via the web (Action ind D, letter type 0 {no letter}) : ${count}\n"
+}
+
+add_total_count_removed_auth_codes () {
+    total_auth_codes_removed=$(dbaccess "${database}" - 2>/dev/null <<EOF
+set isolation to dirty read;
+select count(*) from doc_auth where
+doc_auth_end_dt = "${today_with_hyphens}"
+EOF
+)
+    exit_on_error "$?" "${FUNCNAME[0]}:${LINENO} dbaccess returned $?"
+
+    total_auth_codes_removed="$(grep -Eo '[0-9]+' <<< "${total_auth_codes_removed}")"
+
+    if [[ $? -ne 0 || -z "${total_auth_codes_removed}" ]]; then
+        error "${FUNCNAME[0]}:${LINENO} Unable to determine row count"
+        exit 1
+    fi
+
+    append_mail_file "Count of auth codes cancelled via EF Admin (No Letter Issued) : $(( total_auth_codes_removed - auth_codes_removed_with_indicators ))\n"
+    append_mail_file "Total count of auth codes removed for ${today_with_hyphens} : ${total_auth_codes_removed}\n\n"
+}
+
+add_auth_codes_total_header () {
+    append_mail_file "Auth code total for the day......\n\n"
+}
+
+add_auth_codes_total_count () {
+    append_mail_file "Daily difference in auth codes for ${today_with_hyphens} : $(( total_auth_codes_added - total_auth_codes_removed ))\n"
+}
+
+append_mail_file () {
+    local message="$1"
+    echo -e "${message}" >> "${mail_file}"
+}
+
+delete_mail_file () {
+    rm -f "${mail_file}"
+}
+
+# -- Stats --------------------------------------------------------------------
+
+send_stats () {
+{% if stats.enabled %}
+    mailx -r "${USER}@$(hostname)" -s "Authentication Code Stats - ${today_with_hyphens}" {% for recipient in stats_config.auth_code_stats %}{{ recipient }} {% endfor %}< "${mail_file}"
+{% else %}
+    echo "Stats disabled; no file(s) will be sent"
+{% endif %}
+}
+
+initialise_logging () {
+    log_level=$(echo "${LOGLEVEL:-INFO}" | tr '[:upper:]' '[:lower:]')
+}
+
+# -- Entrypoint ---------------------------------------------------------------
+
+main () {
+    initialise_logging
+    check_user
+    create_mail_file
+
+    add_stats_header
+
+    add_auth_code_additions_header
+    add_auth_change_action_n_count
+    add_doc_auth_inc_count
+    add_auth_change_action_r_count
+    add_auth_change_action_p_count
+    add_auth_codes_count_for_eshuttles
+    add_auth_codes_count_for_bulk_loads
+    add_auth_codes_count_for_ef_admin
+    add_total_count_new_auth_codes
+
+    add_auth_code_reminder_letters_header
+    add_doc_change_action_c_count
+
+    add_auth_code_removals_header
+    add_auth_codes_count_for_bulk_removals
+    add_auth_codes_count_for_cancelled_via_web
+    add_total_count_removed_auth_codes
+
+    add_auth_codes_total_header
+    add_auth_codes_total_count
+
+    send_stats
+    delete_mail_file
+}
+
+main "${@}"

--- a/scripts/auth_diss.j2
+++ b/scripts/auth_diss.j2
@@ -1,0 +1,252 @@
+#!/bin/bash
+
+# Disable auth codes for dissolved companies. Set 'LOGLEVEL' environment variable
+# to the value 'trace' for additional logging.
+
+source "{{ informix_install_path }}/etc/informix.env.${USER}"
+
+# -- Internal variables -------------------------------------------------------
+
+script_name=$(basename "$0")
+
+database="ef_db"
+
+chips_auth_dissolved_output_dir=""
+
+output_file_dir="${HOME}/dat/dissolved/complete"
+archive_file_dir="${HOME}/dat/dissolved/archive"
+
+auth_code_digit_count="5"
+
+log_file="{{ tuxedo_logs_path }}/${USER}/${script_name}.log"
+
+# -- General ------------------------------------------------------------------
+
+log () {
+    local level="${1}"
+    local message="$(echo -e ${2})"
+    echo -e  "$(date --iso-8601=seconds) ${level} ${message}" | tee -a "${log_file}"
+}
+
+trace () {
+    local message="${1}"
+    if [[ "${log_level}" == "trace" ]]; then
+        log "TRACE" "${message}"
+    fi
+}
+
+error () {
+    local message="${1}"
+    log "ERROR" "${message}"
+}
+
+info () {
+    local message="${1}"
+    log "INFO" "${message}"
+}
+
+check_user () {
+    if [[ "${USER}" == "root" ]]; then
+        error "${script_name}: This script should be executed as a Tuxedo service user not root"
+        exit 1
+    fi
+}
+
+set_input_files () {
+    input_files=( $(ls ${chips_auth_dissolved_output_dir}) )
+    if [[ "{{ '${#input_files[@]}' }}" -eq 0 ]]; then
+        error "There are no input files to process"
+        return 1
+    fi
+    trace "${FUNCNAME[0]}:${LINENO} input_files=(${input_files[*]})"
+
+    return 0
+}
+
+check_dissolved_dirs () {
+    local dissolved_dir_vars=(
+        "chips_auth_dissolved_output_dir"
+    )
+
+    local errors="false"
+
+    for dissolved_dir_var in "${dissolved_dir_vars[@]}"; do
+        if [[ -z "${!dissolved_dir_var}" ]]; then
+            error "Script variable '${dissolved_dir_var}' is not set"
+            errors="true"
+        elif [[ ! -d "${!dissolved_dir_var}" ]]; then
+            error "Script variable '${dissolved_dir_var}' references the path '${!dissolved_dir_var}' which does not exist"
+            errors="true"
+        fi
+    done
+
+    if [[ "${errors}" == "true" ]]; then
+        exit 1
+    fi
+}
+
+exit_on_error () {
+    local exit_code="$1"
+    local message="$2"
+
+    if [[ "${exit_code}" -ne 0 ]]; then
+        error "${message}"
+        exit 1
+    fi
+}
+
+create_mail_file () {
+    mail_file=$(mktemp -t "${script_name}.XXXXXXX")
+    exit_on_error "$?" "Unable to create temporary mail file (${FUNCNAME[0]}:${LINENO})"
+}
+
+disable_auth_codes () {
+    local company_number="$1"
+
+    trace "${FUNCNAME[0]}:${LINENO} company_number=${company_number}"
+
+    info "Disabling auth code(s) for company number '${company_number}'"
+
+    dbaccess "${database}" - >/dev/null 2>&1 <<EOF
+update doc_auth set doc_auth_end_dt = CURRENT,
+doc_auth_closed_by = "dissolved job"
+where doc_auth_co_no = "${company_number}"
+and doc_auth_end_dt is NULL;
+EOF
+    exit_on_error "$?" "${FUNCNAME[0]}:${LINENO} dbaccess returned $?"
+}
+
+process_input_file () {
+    local input_file_path="$1"
+    local output_file_path="${output_file_dir}/$(basename "${input_file_path}").complete"
+
+    trace "${FUNCNAME[0]}:${LINENO} input_file_path=${input_file_path} output_file_path=${output_file_path}"
+
+    info "Starting input file processing for ${input_file_path}"
+
+    local count=0
+
+    while read -r company_number; do
+        if [[ -z "${company_number}" ]]; then
+            continue
+        fi
+
+        disable_auth_codes "${company_number}"
+        info "Company number '${company_number}' dissolved"
+        (( count += 1))
+
+        info "Writing to output file '${output_file_path}'"
+        echo "${company_number}" >> "${output_file_path}"
+
+    done < "${input_file_path}"
+
+    append_mail_file "${count} companies have had their auth codes closed off today (original input file: '$(basename ${input_file_path})')"
+
+    info "Finished input file processing for ${input_file_path}"
+}
+
+create_dir_if_not_exists () {
+    local dir_path="${1}"
+
+    if [[ ! -d "${dir_path}" ]]; then
+        info "Creating directory '${dir_path}'"
+        mkdir -p "${dir_path}"
+        if [[ "$?" -ne 0 ]]; then
+            error "Unable to create directory '${dir_path}'"
+            exit 1
+        fi
+    fi
+}
+
+process_input_files () {
+    while read -r -d $'\0' input_file_path; do
+        process_input_file "${input_file_path}"
+        archive_input_file "${input_file_path}"
+        delete_input_file "${input_file_path}"
+    done < <(find "${chips_auth_dissolved_output_dir}" -maxdepth 1 -type f -print0)
+}
+
+archive_input_file () {
+    local input_file_path="$1"
+    local archive_file_path="${archive_file_dir}/$(basename ${input_file_path})"
+
+    trace "${FUNCNAME[0]}:${LINENO} input_file_path=${input_file_path} archive_file_path=${archive_file_path}"
+
+    info "Archiving file '${input_file_path}' to path '${archive_file_path}'"
+
+    cp -f "${input_file_path}" "${archive_file_path}"
+    if [[ "$?" -ne 0 ]]; then
+        error "Unable to copy input file to archive directory"
+        exit 1
+    fi
+}
+
+delete_input_file () {
+    local input_file_path="$1"
+
+    trace "${FUNCNAME[0]}:${LINENO} input_file_path=${input_file_path}"
+
+    info "Deleting file '${input_file_path}'"
+
+    rm -f "${input_file_path}"
+}
+
+initialise_logging () {
+    log_level=$(echo "${LOGLEVEL:-INFO}" | tr '[:upper:]' '[:lower:]')
+}
+
+append_mail_file () {
+    local message="$1"
+    echo -e "${message}" >> "${mail_file}"
+}
+
+delete_mail_file () {
+    rm -f "${mail_file}"
+}
+
+# -- Alerts -------------------------------------------------------------------
+
+send_alert () {
+{% if alerts.enabled %}
+    mailx -r "${USER}@$(hostname)" -s "WARNING - auth_diss - $(date)" {% for recipient in alerts_config.auth_diss %}{{ recipient }} {% endfor %}< "${mail_file}"
+{% else %}
+    echo "Alerts disabled; no mail message(s) will be generated"
+{% endif %}
+}
+
+# -- Stats --------------------------------------------------------------------
+
+send_stats () {
+{% if stats.enabled %}
+    mailx -r "${USER}@$(hostname)" -s "INFO - auth_diss - $(date)" {% for recipient in stats_config.auth_diss %}{{ recipient }} {% endfor %}< "${mail_file}"
+{% else %}
+    echo "Stats disabled; no file(s) will be sent"
+{% endif %}
+}
+
+# -- Entrypoint ---------------------------------------------------------------
+
+main () {
+    initialise_logging
+    check_user
+    check_dissolved_dirs
+    create_mail_file
+
+    if ! set_input_files; then
+        append_mail_file "There are no input files to process.\n"
+        send_alert
+        delete_mail_file
+        exit 1
+    fi
+
+    create_dir_if_not_exists "${output_file_dir}"
+    create_dir_if_not_exists "${archive_file_dir}"
+
+    process_input_files
+
+    append_mail_file ""
+    send_stats
+    delete_mail_file
+}
+
+main "${@}"

--- a/scripts/auth_letter.j2
+++ b/scripts/auth_letter.j2
@@ -15,8 +15,8 @@ database="ef_db"
 chips_auth_shuttle_input_dir=""
 chips_auth_shuttle_output_dir=""
 
-output_file_dir="${HOME}/eshuttle/done"
-archive_file_dir="${HOME}/eshuttle/archive"
+output_file_dir="${HOME}/dat/eshuttle/complete"
+archive_file_dir="${HOME}/dat/eshuttle/archive"
 
 auth_code_digit_count="5"
 
@@ -302,7 +302,7 @@ disable_auth_codes () {
 
 process_input_file () {
     local input_file_path="$1"
-    local output_file_path="${output_file_dir}/$(basename "${input_file_path}").done"
+    local output_file_path="${output_file_dir}/$(basename "${input_file_path}").complete"
 
     trace "${FUNCNAME[0]}:${LINENO} input_file_path=${input_file_path} output_file_path=${output_file_path}"
 
@@ -363,7 +363,7 @@ process_input_file () {
 
     cp -f "${output_file_path}" "${chips_auth_shuttle_input_dir}"
     if [[ "$?" -ne 0 ]]; then
-        error "Unable to copy ouput file to shuttle input directory"
+        error "Unable to copy output file to shuttle input directory"
         exit 1
     fi
 
@@ -401,7 +401,7 @@ archive_input_file () {
 
     cp -f "${input_file_path}" "${archive_file_path}"
     if [[ "$?" -ne 0 ]]; then
-        error "Unable to copy ouput file to shuttle input directory"
+        error "Unable to copy input file to archive directory"
         exit 1
     fi
 }

--- a/scripts/auth_letters.j2
+++ b/scripts/auth_letters.j2
@@ -102,7 +102,7 @@ delete_unload_file () {
 
 run_auth_letters () {
     log "Starting auth letters procedure"
-    "${app_dir}/auth_letters"
+    "${app_dir}/auth_letters" 2>&1 | tee -a "${log_file}"
     log "Finished auth letters procedure"
 }
 


### PR DESCRIPTION
These scripts have been migrated from  on-premise `che-fil` hosts and rewritten for `bash` rather than `ksh` with additional logic for safety and trace logging.

Resolves: `DVOP-2231`