### PR TITLE
Catch extract process errors and generate alert

### DIFF
--- a/scripts/scud/scud_extract.j2
+++ b/scripts/scud/scud_extract.j2
@@ -78,6 +78,7 @@ create_extract_file () {
     fi
 
     source "${config_dir}/envfile" && "${app_dir}/extract" >> "${log_file}"
+    exit_on_error "$?" "Exection of extract process failed: '${app_dir}/extract'"
 
     if [[ ! -f "${extract_file}" ]]; then
         exit_with_error "Extract file was not created at '${extract_file}'"

--- a/scripts/scud/scud_extract.j2
+++ b/scripts/scud/scud_extract.j2
@@ -78,7 +78,7 @@ create_extract_file () {
     fi
 
     source "${config_dir}/envfile" && "${app_dir}/extract" >> "${log_file}"
-    exit_on_error "$?" "Exection of extract process failed: '${app_dir}/extract'"
+    exit_on_error "$?" "Execution of extract process failed: '${app_dir}/extract'"
 
     if [[ ! -f "${extract_file}" ]]; then
         exit_with_error "Extract file was not created at '${extract_file}'"


### PR DESCRIPTION
This change ensures that the SCUD extract process is halted and an email alert generated based on error conditions such as database connectivity failures. See also https://github.com/companieshouse/fil-tuxedo/pull/23 for context.